### PR TITLE
pyyaml 6.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
     - 0001-Ensure-we-do-not-end-up-wih-CRLF-line-endings-on-tes.patch
 
 build:
-  number: 1
+  number: 
   skip: True  # [py<36]
   script:
     - python setup.py --with-libyaml build_ext --include-dirs="${PREFIX}/include" --library-dirs="${PREFIX}/lib"  # [unix]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,6 +12,7 @@ source:
 
 build:
   number: 1
+  skip: True  # [py<36]
   script:
     - python setup.py --with-libyaml build_ext --include-dirs="${PREFIX}/include" --library-dirs="${PREFIX}/lib"  # [unix]
     - python setup.py --with-libyaml build_ext --include-dirs="%LIBRARY_INC%" --library-dirs="%LIBRARY_LIB%"      # [win]
@@ -21,9 +22,13 @@ build:
 requirements:
   build:
     - {{ compiler('c') }}
+    - patch  # [now win]
+    - m2-patch  # [win]
   host:
     - python
     - cython
+    - setuptools
+    - wheel
     - yaml
   run:
     - python
@@ -33,6 +38,11 @@ test:
   imports:
     - yaml
     - _yaml   # [python_impl == "cpython"]
+  requires:
+    - pip
+  commands:
+    # temporarily skipping pip check on win and pypy build because of bizarre tqdm issue
+    - pip check  # [not (win and python_impl == 'pypy')]
 
 about:
   home: http://pyyaml.org/wiki/PyYAML

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,7 +23,7 @@ requirements:
   build:
     - {{ compiler('c') }}
     - m2-patch  # [win]
-    - patch  # [now win]
+    - patch  # [not win]
   host:
     - python
     - cython

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "5.4.1" %}
+{% set version = "6.0" %}
 
 package:
   name: pyyaml
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/P/PyYAML/PyYAML-{{ version }}.tar.gz
-  sha256: 607774cbba28732bfa802b54baa7484215f530991055bb562efbed5b2f20a45e
+  sha256: 68fb519c14306fec9720a2a5b45bc9f0c8d1b9c72adf45c37baedfcd949c35a2
   patches:
     - 0001-Ensure-we-do-not-end-up-wih-CRLF-line-endings-on-tes.patch
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
     - 0001-Ensure-we-do-not-end-up-wih-CRLF-line-endings-on-tes.patch
 
 build:
-  number: 
+  number: 0
   skip: True  # [py<36]
   script:
     - python setup.py --with-libyaml build_ext --include-dirs="${PREFIX}/include" --library-dirs="${PREFIX}/lib"  # [unix]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,8 +22,8 @@ build:
 requirements:
   build:
     - {{ compiler('c') }}
-    - patch  # [now win]
     - m2-patch  # [win]
+    - patch  # [now win]
   host:
     - python
     - cython


### PR DESCRIPTION
Update pyyaml to 6.0

Category:  miniconda | subcategory:  dependency | pkg_type:  python
Popularity:  13986705 downloads -  pyyaml  6.0  YAML parser and emitter for Python
Version change: bump version number from 5.4.1 to 6.0 (Major version bump!)
  license: MIT
Release date:  Oct 13, 2021
Bug Tracker: new open issues https://github.com/yaml/pyyaml/issues
License file:  https://github.com/yaml/pyyaml/blob/master/LICENSE
Upstream Changelog: https://github.com/yaml/pyyaml/blob/master/CHANGES
Upstream setup.py:  https://github.com/yaml/pyyaml/blob/6.0/setup.py
Upstream pyproject.toml:  https://github.com/yaml/pyyaml/blob/6.0/pyproject.toml

Actions:
1. Add skip py<37
2. Add missing packages: `setuptools`, `wheel`
3. Add (m2)-patch
4. Add `pip check`

Result:
- all-succeeded