### PR TITLE
raise build-number, adjust build scripting to run

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,13 +11,17 @@ source:
     - 0001-Ensure-we-do-not-end-up-wih-CRLF-line-endings-on-tes.patch
 
 build:
-  number: 0
+  number: 1
   skip: True  # [py<36]
   script:
-    - python setup.py --with-libyaml build_ext --include-dirs="${PREFIX}/include" --library-dirs="${PREFIX}/lib"  # [unix]
-    - python setup.py --with-libyaml build_ext --include-dirs="%LIBRARY_INC%" --library-dirs="%LIBRARY_LIB%"      # [win]
-    - python setup.py install
-    - python setup.py test
+    - >-
+        "{{ PYTHON }}" -m pip install .
+        --global-option="--with-libyaml"
+        --global-option="build_ext"
+        --global-option="-I${PREFIX}/include"  # [unix]
+        --global-option="-L${PREFIX}/lib"      # [unix]
+        --global-option="-I%LIBRARY_INC%"      # [win]
+        --global-option="-L%LIBRARY_LIB%"      # [win]
 
 requirements:
   build:
@@ -28,6 +32,7 @@ requirements:
     - python
     - cython
     - setuptools
+    - pip
     - wheel
     - yaml
   run:


### PR DESCRIPTION
Fix broken logic in recipe about invoking python ... here not host's variant, but a random on system is invoked, and might lead even to empty or broken package.
