### PR TITLE
building 5.4.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -50,7 +50,7 @@ test:
     - pip check  # [not (win and python_impl == 'pypy')]
 
 about:
-  home: http://pyyaml.org/wiki/PyYAML
+  home: https://pyyaml.org/wiki/PyYAML
   license_file: LICENSE
   license: MIT
   license_family: MIT
@@ -58,8 +58,7 @@ about:
   description: |
     YAML is a data serialization format designed for human readability and interaction with
     scripting languages.
-  doc_url: http://pyyaml.org/wiki/PyYAMLDocumentation
-  doc_source_url: http://pyyaml.org/browser/pyyaml/trunk/README
+  doc_url: https://pyyaml.org/wiki/PyYAMLDocumentation
   dev_url: https://github.com/yaml/pyyaml
 
 extra:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "6.0" %}
+{% set version = "5.4.1" %}
 
 package:
   name: pyyaml
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/P/PyYAML/PyYAML-{{ version }}.tar.gz
-  sha256: 68fb519c14306fec9720a2a5b45bc9f0c8d1b9c72adf45c37baedfcd949c35a2
+  sha256: 607774cbba28732bfa802b54baa7484215f530991055bb562efbed5b2f20a45e
   patches:
     - 0001-Ensure-we-do-not-end-up-wih-CRLF-line-endings-on-tes.patch
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
     - 0001-Ensure-we-do-not-end-up-wih-CRLF-line-endings-on-tes.patch
 
 build:
-  number: 1
+  number: 0
   skip: True  # [py<36]
   script:
     - >-


### PR DESCRIPTION
Building older version 5.4.1 due to a third party package that depends on pyyaml<6 we need builds of pyyaml 5.4.1 for Python 3.10 and Python 3.11 from Anaconda.

## Changes
- version number
- builder number
- sha256
- `removed dev_source_url` since we have a `doc_url`
- updated links to have `https`