### PR TITLE
pyyaml v6.0.2

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ source:
 
 build:
   number: 0
-  skip: True  # [py<36]
+  skip: True  # [py<38]
 
 requirements:
   build:
@@ -22,7 +22,7 @@ requirements:
     - patch  # [not win]
   host:
     - python
-    - cython <3.0
+    - cython       # [py<=312]
     - cython >3.0  # [py>=313]
     - setuptools
     - pip

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "PyYAML" %}
-{% set version = "6.0.1" %}
+{% set version = "6.0.2" %}
 
 package:
   name: {{ name|lower }}
@@ -8,6 +8,7 @@ package:
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
   sha256: bfdf460b1736c775f2ba9f6a92bca30bc2095067b8a9d77876d1fad6cc3b4a43
+  sha256: d584d9ec91ad65861cc08d42e834324ef890a082e591037abe114850ff7bbc3e
   patches:
     - 0001-Ensure-we-do-not-end-up-wih-CRLF-line-endings-on-tes.patch
 
@@ -23,6 +24,7 @@ requirements:
   host:
     - python
     - cython <3.0
+    - cython >3.0  # [py>=313]
     - setuptools
     - pip
     - wheel

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -6,8 +6,7 @@ package:
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: bfdf460b1736c775f2ba9f6a92bca30bc2095067b8a9d77876d1fad6cc3b4a43
+  url: https://pypi.io/packages/source/{{ name[0]|lower }}/{{ name|lower }}/{{ name|lower }}-{{ version }}.tar.gz
   sha256: d584d9ec91ad65861cc08d42e834324ef890a082e591037abe114850ff7bbc3e
   patches:
     - 0001-Ensure-we-do-not-end-up-wih-CRLF-line-endings-on-tes.patch


### PR DESCRIPTION
pyyaml v6.0.2

**Destination channel:** defaults

### Links

- [PKG-5687](https://anaconda.atlassian.net/browse/PKG-5687) 
- [Upstream repository](https://github.com/yaml/pyyaml/tree/6.0.2)
- [Upstream changelog/diff](https://github.com/yaml/pyyaml/releases/tag/6.0.2)
- [pyproject.toml](https://github.com/yaml/pyyaml/blob/6.0.2/pyproject.toml)

### Explanation of changes:

- Bump version and SHA
- Fix the url
- Update cypthon pinnings 


[PKG-5687]: https://anaconda.atlassian.net/browse/PKG-5687?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ