### PR TITLE
pyyaml 6.0.3 

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,2 @@
 build_env_vars:
-  ANACONDA_ROCKET_ENABLE_PY313 : yes
+  ANACONDA_ROCKET_ENABLE_PY314 : yes

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -1,7 +1,7 @@
 @echo on
 
 %PYTHON% -m pip install . --no-deps --no-build-isolation ^
-        --global-option="--with-libyaml" ^
-        --global-option="build_ext" ^
-        --global-option="-I%LIBRARY_INC%" ^
-        --global-option="-L%LIBRARY_LIB%"
+        --config-settings="--global-option=--with-libyaml" ^
+        --config-settings="--global-option=build_ext" ^
+        --config-settings="--global-option=-I%LIBRARY_INC%" ^
+        --config-settings="--global-option=-L%LIBRARY_LIB%"

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -5,7 +5,7 @@ set -x
 cd ${SRC_DIR}
 
 $PYTHON -m pip install . --no-deps --no-build-isolation \
-        --global-option="--with-libyaml" \
-        --global-option="build_ext" \
-        --global-option="-I$PREFIX/include" \
-        --global-option="-L$PREFIX/lib"
+        --config-settings="--global-option=--with-libyaml" \
+        --config-settings="--global-option=build_ext" \
+        --config-settings="--global-option=-I${PREFIX}/include" \
+        --config-settings="--global-option=-L${PREFIX}/lib"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,32 +1,30 @@
 {% set name = "PyYAML" %}
-{% set version = "6.0.2" %}
+{% set version = "6.0.3" %}
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0]|lower }}/{{ name|lower }}/{{ name|lower }}-{{ version }}.tar.gz
-  sha256: d584d9ec91ad65861cc08d42e834324ef890a082e591037abe114850ff7bbc3e
+  url: https://pypi.org/packages/source/{{ name[0]|lower }}/{{ name|lower }}/{{ name|lower }}-{{ version }}.tar.gz
+  sha256: d76623373421df22fb4cf8817020cbb7ef15c725b9d5e45f17e189bfc384190f
   patches:
     - 0001-Ensure-we-do-not-end-up-wih-CRLF-line-endings-on-tes.patch
 
 build:
   number: 0
-  skip: True  # [py<38]
+  skip: true  # [py<38]
 
 requirements:
   build:
+    - {{ stdlib('c') }}
     - {{ compiler('c') }}
-    - m2-patch  # [win]
-    - patch  # [not win]
   host:
     - python
     - cython
     - setuptools
     - pip
-    - wheel
-    - yaml 0.2.5
+    - yaml {{ yaml }}
   run:
     - python
     - yaml
@@ -34,13 +32,17 @@ requirements:
 test:
   imports:
     - yaml
+  source_files:
+    - tests/
   requires:
     - pip
+    - pytest
   commands:
     - pip check
+    - pytest -v tests
 
 about:
-  home: https://pyyaml.org/wiki/PyYAML
+  home: https://pyyaml.org
   license_file: LICENSE
   license: MIT
   license_family: MIT


### PR DESCRIPTION
pyyaml 6.0.3 

**Destination channel:** Defaults

### Links

- [PKG-10738]
- dev_url:        https://github.com/yaml/pyyaml/tree/6.0.3
- conda_forge:    https://github.com/conda-forge/pyyaml-feedstock
- pypi:           https://pypi.org/project/pyyaml/6.0.3
- pypi inspector: https://inspector.pypi.io/project/pyyaml/6.0.3

### Explanation of changes:

- new version number - from 6.0.2 to 6.0.3
- use `--config-settings` param as newer version of `pip` doesn't support anymore `--global-option`
- enable build for py314
- add testing


[PKG-10738]: https://anaconda.atlassian.net/browse/PKG-10738?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ